### PR TITLE
Fixed missing double quote on batt_topic in sample configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Sample HomeBridge Configuration
           "name": "Living Room Temperature",
           "url": "mqtt://localhost",
           "topic": "home/livingroom/temperature/value",
-          "batt_topic: "home/livingroom/temperature/battery",
+          "batt_topic": "home/livingroom/temperature/battery",
           "charge_topic": "home/livingroom/temperature/charge",
           "batt_low_perc": "33",
           "username": "username",


### PR DESCRIPTION
The sample configuration file was missing a double quote on the batt_topic property. It took me a while to find this whilst setting it up. 